### PR TITLE
config: Fix dtc patch with cross compilation env

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -1,6 +1,6 @@
 SOURCES := $(shell find $(SOURCEDIR) -name '*.dts')
 OBJECTS = $(SOURCES:.dts=.dtb)
-DTC = dtc
+DTC ?= dtc
 
 all: $(OBJECTS)
 


### PR DESCRIPTION
On cross compiled environment, the compilation host dtc should not be used from its $PATH. The dtc tool shall be provided at runtime.