### PR TITLE
config: support external DTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ the following command can be run:
 ```bash
 [~/mc-utils] $ make -C config/
 ```
+
+## Build Options
+
+The `Makefile` supports two customizations:
+
+- `DTC`: Specify the path to the Device Tree Compiler (DTC).
+- `SOURCES`: Provide an external set of Device Tree Source (DTS) files,
+  which should be space-separated.
+
+For instance, to build with a specific DTC path and external DTS files, you can run:
+
+```bash
+[~/mc-utils] $ make DTC=/dev/br_build/host/bin/dtc SOURCES="path1/file1.dts path2/file2.dts" -C config/
+```
+
+In this example, the `make` command is used to specify the path to the DTC and include
+additional DTS files from the specified paths.

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,4 +1,4 @@
-SOURCES := $(shell find $(SOURCEDIR) -name '*.dts')
+SOURCES += $(shell find $(SOURCEDIR) -name '*.dts')
 OBJECTS = $(SOURCES:.dts=.dtb)
 DTC ?= dtc
 


### PR DESCRIPTION
In order to be able to use mc-utils with some external DTS of DPC and DPL, we should be able to run make with SOURCES such as:
  DTC=/pathto/bin/dtc SOURCES="/pathto/dpc /pathto/dpl" make -C pathto/config/